### PR TITLE
feat(projects): facilitate user the option to go to github from the task

### DIFF
--- a/rf/hook_events/task.py
+++ b/rf/hook_events/task.py
@@ -1,3 +1,0 @@
-def update_task_details(doc, method):
-    if doc.github_pr and not doc.db_get("github_pr"):
-        doc.status = "Needs Code Review"

--- a/rf/hooks.py
+++ b/rf/hooks.py
@@ -31,6 +31,9 @@ app_license = "MIT"
 # doctype_tree_js = {"doctype" : "public/js/doctype_tree.js"}
 # doctype_calendar_js = {"doctype" : "public/js/doctype_calendar.js"}
 
+doctype_js = {"Task" : "public/js/task.js"}
+
+
 # Home Pages
 # ----------
 
@@ -86,12 +89,6 @@ app_license = "MIT"
 # 		"on_trash": "method"
 #	}
 # }
-
-doc_events = {
-	"Task": {
-		"validate": "rf.hook_events.task.update_task_details",
-	}
-}
 
 # Scheduled Tasks
 # ---------------

--- a/rf/public/js/task.js
+++ b/rf/public/js/task.js
@@ -1,0 +1,14 @@
+frappe.ui.form.on('Task', {
+	refresh: function (frm) {
+		if (!frm.is_new()) {
+			if (frm.doc.github_pr) {
+				frm.add_custom_button(__("Pull Request"), () => {
+					window.open(frm.doc.github_pr);
+				}, __("Go to"));
+			};
+		}
+	},
+	github_pr: function (frm) {
+		frm.set_value('status', 'Needs Code Review')
+	}
+});


### PR DESCRIPTION
**Task:** [TASK-2020-00049](http://rf.resourcefactors.com/desk#Form/Task/TASK-2020-00049)

**Additions:**

- Let the user change the status of the task after inserting the github link.

- Button that takes the user to the github PR page.

**Screenshots/Gifs:**

1. Change the task status after entering Github PR link-


![task-status](https://user-images.githubusercontent.com/13060550/87582355-ec2fd180-c6f7-11ea-87bb-d2e2fa3bad00.gif)


2. Button to go to the PR-

![goto-pr](https://user-images.githubusercontent.com/13060550/87582417-fbaf1a80-c6f7-11ea-9519-23fffd52067a.gif)

